### PR TITLE
Fix issue where fetch-X.sh scripts not running

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,3 +73,4 @@ RUN git clone https://github.com/p1-dsop/dsop-rke2 working/dsop_rke2
 
 
 RUN chmod +x working/dsop_rke2/example/run_after_deploy.sh
+RUN chmod +x working/dsop_rke2/scripts/*.sh

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ PyBuilder is a Python3 app (Python3 and everything else you'll need is already i
     cd working/dsop_rke2/example
     source run_after_deploy.sh 
 ```
-- Executing the app: `python3 main.app --help`
+- Executing the app: `python3 main.py --help`
 - Displaying the variables you can configure: `python3 main.py --settings=y`
 - Editing the values you need to modify for Terraform: Update the _config.json_ file in the _config_ folder with the values you'd like Terraform to use to deploy the solution. See the Section below that discusses each variable.
 - Deploying the RKE2 Big Bang on Azure platform: `python3 main.app --deploy=y`

--- a/util/streams.py
+++ b/util/streams.py
@@ -74,14 +74,15 @@ class Stream:
         args = ['terraform', f"-chdir={self.get_work_dir()}/example", 'apply', '-auto-approve']
         res = self._run_process(args)
         self._copy_scripts()
-        res = self._run_process('fetch-kubeconfig.sh', True, f"{self.get_work_dir()}/example", shell=False)
+        res = self._run_process('./fetch-kubeconfig.sh', True, cwd=f"{self.get_work_dir()}/example", shell=False)
         logger.debug(f"fetch-kubeconfig.sh: {res}\n")
-        res = self._run_process('fetch-ssh-key.sh', True, f"{self.get_work_dir()}/example", shell=False)
+        res = self._run_process('./fetch-ssh-key.sh', True, cwd=f"{self.get_work_dir()}/example", shell=False)
         logger.debug(f"fetch-ssh-key.sh: {res}\n")
         self.cout_success(res)
     
     def _copy_scripts(self):
-        res = self._run_process(['cp', '/PyBuilder/working/dsop_rke2/scripts/*', '/PyBuilder/working/dsop_rke2/example'])
+        res = self._run_process(['cp', '/PyBuilder/working/dsop_rke2/scripts/fetch-kubeconfig.sh', '/PyBuilder/working/dsop_rke2/example'])
+        res = self._run_process(['cp', '/PyBuilder/working/dsop_rke2/scripts/fetch-ssh-key.sh', '/PyBuilder/working/dsop_rke2/example'])
         logger.debug(f"Copying script files to example directory")
     
         


### PR DESCRIPTION
the fetch-kubeconfig.sh and fetch-ssh-key.sh scripts were not executing after the completion of terraform. This was largely because 

1. the cp command was not respecting `*`
2. the commands were not executable
3. they needed a `./` in front of them because the cwd was not in the PATH

Tested on a locally built image and deployed to my Azure subscription.