### PR TITLE
Add support for AKS Deployments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,7 @@ WORKDIR /PyBuilder
 RUN ls -l
 RUN pip install -r requirements.txt
 RUN git clone https://github.com/p1-dsop/dsop-rke2 working/dsop_rke2
+RUN git clone https://github.com/timothymeyers/dsop-aks working/dsop_aks
 #RUN git clone git@github.com:p1-dsop/dsop-environment.git working/bigbang
 
 RUN chmod +x working/dsop_rke2/scripts/check-terraform.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,8 @@ WORKDIR /PyBuilder
 RUN ls -l
 RUN pip install -r requirements.txt
 RUN git clone https://github.com/p1-dsop/dsop-rke2 working/dsop_rke2
+
+# TODO: Need to update this to point to p1-dsop after forking
 RUN git clone https://github.com/timothymeyers/dsop-aks working/dsop_aks
 #RUN git clone git@github.com:p1-dsop/dsop-environment.git working/bigbang
 

--- a/README.md
+++ b/README.md
@@ -1,27 +1,34 @@
 [![Continuous Build, Test, Deploy](https://github.com/marlinspike/dsopbuilder/actions/workflows/docker-build.yml/badge.svg)](https://github.com/marlinspike/dsopbuilder/actions/workflows/docker-build.yml)
 
 # DSOPBuilder and PyBuilder #
+
 DevSecOps Builder (DSOPBuilder) is the complete toolset to create a Platform One Big Bang DevSecOps stack on Azure, running on Rancher RKE2. The toolset consists of the following:
+
 - DSOPBuilder Docker Image: The docker image contains all the required tools and the cloned Git Repos to deploy the Azure Infrastructure using Terraform.
 - PyBuilder: The *PyBuilder* Python app provides an easy way to deploy the entire stack and automates many manual steps. PyBuilder allows you to configure the Terraform _tfvars_ file via the config file provided.
 
 The total deploy time is approximately *6-7 minutes*.
 
 ### Running DSOP Builder ###
+
 The [DSOPBuilder Docker image](https://hub.docker.com/r/shuffereu/dsopbuilder) is automatically built and pushed to my DockerHub container repository. The DSOPBuilder image contains the PyBuilder app you'll use to deploy P1 DevSecOps to Azure.
 
 ## Pulling and Running the Image from DockerHub ##
+
 First make sure you have [Docker Desktop](https://docs.docker.com/get-docker/) installed on your machine. To pull the image:
 `docker pull shuffereu/dsopbuilder`
 
 ### Running the image ###
+
 To run the image you pulled earlier:
 `docker run -it shuffereu/dsopbuilder`
-The _-it_ parameter tells Docker that you want to shell into the running container.
+The *-it* parameter tells Docker that you want to shell into the running container.
 
 ## Configuring PyBuilder
+
 The PyBuilder configuration file, found at *config/config.json* must be configured. Here's what that file looks like:
-```
+
+```json
 {
     "general": {
         "cluster_name": "dsop_rke2",
@@ -52,20 +59,23 @@ The PyBuilder configuration file, found at *config/config.json* must be configur
 Here's what the parameters mean:
 
 **General**
+
 - cluster_name: The name of the RKE2 Kubernetes Cluster
 - cloud: "AzureUSGovernmentCloud" here means Azure Government
 - location: The Azure Region to deploy in
 
 **Cluster-Size**
+
 - server_instance_count: Number of masters
 - agent_instance_count: Number of nodes required
 - vm_size: Azure VM SKU. Make sure this SKU exists in the Cloud and Region configured
 
 **Connectivity**
+
 - server_public_ip: True if you need a Public IP for your cluster; False otherwise
 
-
 ## Running PyBuilder ##
+
 PyBuilder is a Python3 app (Python3 and everything else you'll need is already installed in the Docker iamge). Basic usage of PyBuilder:
 
 PyBuilder's command interface is easy to use, and help is built in.
@@ -73,7 +83,8 @@ PyBuilder's command interface is easy to use, and help is built in.
 *Command*: `python3 main.py --help`
 
 This prints out the following information:
-```
+
+```text
 Usage: main.py [OPTIONS] COMMAND [ARGS]...
 
 Options:
@@ -114,7 +125,8 @@ Commands:
 ```
 
 - Use the *azaccount* subcommand to show the currently logged in Azure Account
-```
+
+```text
 ┏━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
 ┃ Cloud Name        ┃ Is Default ┃ Tenant ID                            ┃ User                                         ┃
 ┡━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
@@ -123,7 +135,8 @@ Commands:
 ```
 
 - Use the *azlist* subcommand to show the currently Active Azure Cloud
-```
+
+```text
 ┏━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┓
 ┃ Cloud Name        ┃ Is Active ┃
 ┡━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━┩
@@ -140,16 +153,35 @@ Commands:
 
 
 ### The rke2 command: Creating an rke2 Cluster in Azure
+
 `python3 main.py rke2 apply`
 
 This command applies the Terraform to build out the Rancher RKE2 cluster in Azure. PyBuilder prompts you for a **Project Name**, which is a folder that it creates and initializes with the Terraform scripts needed.
 
 **Important:** The final step to being able to use *kubectl* to control your cluster requires you to execute the script file indicated after you've run *rke2 apply*.
 
-```
+```bash
 Deployment Completed!
 Your deployment folder is: /PyBuilder/working/dsop_rke2/foo
 Next Steps:
 1. Change to the deployment folder:  cd working/dsop_rke2/foo
 2. Export the KubeConfig:  source ../scripts/fetch-kubeconfig.sh
+```
+
+### The aks command: Creating an Azure Kubernetes Service (AKS) cluster in Azure
+
+`python3 main.py aks apply`
+
+This command applies the Terraform to build out the Rancher RKE2 cluster in Azure. PyBuilder prompts you for a **Project Name**, which is a folder that it creates and initializes with the Terraform scripts needed.
+
+**Important 1:** This deploys AKS with limited RBAC permissions. You must supply an Azure Active Directory (AAD) Group ID that will maintain access rights to the cluster. All users who wish to access the cluster must be part of this AAD Group. This is set in config.json as `aad_group_ids` setting - it is a list of Group IDs.
+
+**Important 2:** The final step to being able to use *kubectl* to control your cluster requires you to use `az aks get-credentials` to obtain cluster configuration.
+
+```bash
+Deployment Completed!
+Your deployment folder is: /PyBuilder/working/dsop_aks/foo
+Next Steps:
+1. Change to the deployment folder:  cd working/dsop_aks/foo
+2. Set KubeConfig:  az aks get-credentials -g $(terraform output -raw rg_name) -n $(terraform output -raw aks_cluster_name)
 ```

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Next Steps:
 
 `python3 main.py aks apply`
 
-This command applies the Terraform to build out the Rancher RKE2 cluster in Azure. PyBuilder prompts you for a **Project Name**, which is a folder that it creates and initializes with the Terraform scripts needed.
+This command applies the Terraform to build out an Azure Kubernetes Service (AKS) cluster in Azure. PyBuilder prompts you for a **Project Name**, which is a folder that it creates and initializes with the Terraform scripts needed.
 
 **Important 1:** This deploys AKS with limited RBAC permissions. You must supply an Azure Active Directory (AAD) Group ID that will maintain access rights to the cluster. All users who wish to access the cluster must be part of this AAD Group. This is set in config.json as `aad_group_ids` setting - it is a list of Group IDs.
 

--- a/command/dsop_aks.py
+++ b/command/dsop_aks.py
@@ -1,0 +1,94 @@
+from sqlite3 import Time
+from util.streams import Stream
+from appsettings import AppSettings
+import pathlib
+import util
+from util.io import *
+import os
+from rich.console import Console
+import time
+import sys
+import logging
+from rich import print
+from rich.panel import Panel
+import typer
+import command.settings as settings
+import command.dsop_aks as dsop_aks
+
+stream = Stream()
+console = Console()
+app = typer.Typer()
+
+
+
+log_format = '%(asctime)s %(filename)s: %(message)s'
+logging.basicConfig(filename='app.log', level=logging.DEBUG, format=log_format, datefmt='%Y-%m-%d %H:%M:%S')
+logger = logging.getLogger(__name__)
+console = Console()
+
+
+
+_app_settings = None
+_working_dir = "working"
+_clone_dsop_aks_dir = "dsop_aks"
+_stream = None
+
+@app.command()
+def apply(
+    project:str = typer.Option("foo", help="Project name for which to initialize Terraform and Scripts. Can be added to a git repo.",prompt="Project Name", confirmation_prompt=True),
+    config:str = typer.Option("n", help="Print app config settings (these configure Azure Cloud Login and Terraform)"),
+    destroy:str = typer.Option("n", help="Destroy the resources created by Terraform. If 'y', Destroy. USE WITH CARE!")):
+    """
+        Applies the AKS Terraform and builds the AKS Cluster in Azure.
+    """
+    Timed()
+    _app_settings = AppSettings()
+    #Ensure that app-settings are valid
+    if(_app_settings.validate() == False):
+        exit(1)
+    
+    _terraform_file = f"{str(pathlib.Path().resolve())}/{_working_dir}/{_clone_dsop_aks_dir}/{project}/terraform.tfvars"
+    _stream = Stream(_clone_dsop_aks_dir, _working_dir, pathlib.Path().resolve(), project_dir=project)
+
+    print(Panel.fit("PyBuilder - The Pythonic Azure Big Bang Deployment Tool\nReuben Cleetus - reuben@cleet.us\nwith Tim Meyers - timothy.m.meyers@gmail.com (AKS deployment)"))
+
+
+    if bool(_app_settings.settings["custom_vnet_settings"]["vnet_customize"]) == False:
+        if os.path.isdir(f"{str(pathlib.Path().resolve())}/{_working_dir}") == False: _stream.Do_No_VNet_Customization()#No VNet Customization
+        _stream.do_rename_terraform_file()
+        _stream.create_proejct_dir()
+        with console.status("Applying Config settings...", spinner="earth"):
+            logger.debug("Applying config settings")
+            splice_file_token(_terraform_file,"cluster_name", _app_settings.settings["general"]["cluster_name"])
+            splice_file_token(_terraform_file, "cloud", _app_settings.settings["general"]["cloud"])
+            splice_file_token(_terraform_file, "location", _app_settings.settings["general"]["location"])
+            splice_file_token(_terraform_file, "server_public_ip", _app_settings.settings["connectivity"]["server_public_ip"])
+            splice_file_token(_terraform_file, "server_open_ssh_public", _app_settings.settings["connectivity"]["server_open_ssh_public"])
+            splice_file_list(_terraform_file, "aad_group_ids", _app_settings.settings["custom_aad_settings_for_aks"]["aad_group_ids"])
+            cout_success("Completed Terraform Token splicing!")
+        with console.status("Initializing Azure-CLI login...", spinner="earth"):
+            logger.debug("Initializing Azure Cloud")
+            if (settings.is_logged_in() == False):
+                cout_error("You're not logged in to Azure. Please log in to Azure to continue.")
+                cout_success("You can use the command: main.py settings azloginusgov to log in to Azure Government")
+                exit(1)
+                #_stream.do_cloud_login()
+                #cout_success("Azure Login Completed.")
+        do_apply = typer.confirm("Continue with Terraform deploy?", abort=True)
+        with console.status("Initializing Terraform...", spinner="earth"):
+            logger.debug("Initializing Terraform")
+            _stream._run_terraform_init()
+            cout_success("Terraform Init Completed!")
+        with console.status("Running Terraform... This may take a while: ", spinner="earth"):
+            logger.debug("Running Terraform")
+            _stream._run_terraform()
+            cout_success("Deployment Completed!")
+            cout_success(f"Your deployment folder is: {str(pathlib.Path().resolve())}/{_working_dir}/{_clone_dsop_aks_dir}/{project}")
+            cout_success("Next Steps: ")
+            cout_success(f"1. Change to the deployment folder:  cd {_working_dir}/{_clone_dsop_aks_dir}/{project}")
+            #cout_success(f"2. Export the KubeConfig:  source ../scripts/fetch-kubeconfig.sh")
+
+    else:
+        #VNet Customization
+        ...
+    Timed()

--- a/command/dsop_aks.py
+++ b/command/dsop_aks.py
@@ -87,6 +87,7 @@ def apply(
             cout_success("Next Steps: ")
             cout_success(f"1. Change to the deployment folder:  cd {_working_dir}/{_clone_dsop_aks_dir}/{project}")
             #cout_success(f"2. Export the KubeConfig:  source ../scripts/fetch-kubeconfig.sh")
+            cout_success(f"2. Set KubeConfig: az aks get-credentials -g $(terraform output -raw rg_name) -n $(terraform output -raw aks_cluster_name)")
 
     else:
         #VNet Customization

--- a/config/config.json
+++ b/config/config.json
@@ -20,6 +20,9 @@
         "external_vnet_name" : "rke2-vnet",
         "external_vnet_subnet_name" : "rke2-subnet"
     },
+    "custom_aad_settings_for_aks" : {
+        "aad_group_ids" : ["00000000-0000-0000-0000-000000000000"]
+    },
     "clone_dsop_repo_name": "dsop_rke2"
   }
   

--- a/main.py
+++ b/main.py
@@ -14,10 +14,12 @@ from rich.panel import Panel
 import typer
 import command.settings as settings
 import command.dsop_rke2 as dsop_rke2
+import command.dsop_aks as dsop_aks
 
 app = typer.Typer()
 app.add_typer(settings.app, name="settings", help="Show and configure Settings information")
 app.add_typer(dsop_rke2.app, name="rke2", help="Apply settings and build a Rancher RKE2 Cluster in Azure")
+app.add_typer(dsop_aks.app, name="aks", help="Apply settings and build an AKS Cluster in Azure")
 
 log_format = '%(asctime)s %(filename)s: %(message)s'
 logging.basicConfig(filename='app.log', level=logging.DEBUG, format=log_format, datefmt='%Y-%m-%d %H:%M:%S')
@@ -29,6 +31,7 @@ console = Console()
 _app_settings = None
 _working_dir = "working"
 _clone_dsop_rke2_dir = "dsop_rke2"
+_clone_dsop_aks_dir = "dsop_aks"
 _stream = None
 _terraform_file = f"{str(pathlib.Path().resolve())}/{_working_dir}/{_clone_dsop_rke2_dir}/example/terraform.tfvars"
 

--- a/util/io.py
+++ b/util/io.py
@@ -29,6 +29,23 @@ def splice_file_token(filename:str, key:str, new_value:str):
     with open(filename, 'w') as fil:
         fil.writelines(lines)
 
+def splice_file_list(filename:str, key:str, new_value:list):
+    '''
+        Replaces the value for the key specified with the new_value list passed, in the filename given.
+    '''
+
+    logger.debug(f"Splicing file: {locals()}")
+    lines = None
+    with open(filename, 'r') as fil:
+        lines = fil.readlines()
+
+    for i, line in enumerate(lines):
+        if key in line.strip():
+            lines[i] = str(f"{key} = {new_value}\n").replace("\'", "\"")
+
+    with open(filename, 'w') as fil:
+        fil.writelines(lines)
+
 
 def do_replace_tokens():
     splice_file_token("", "cluster_name")


### PR DESCRIPTION
Initial updates to allow for aks deployments via the PyBuilder app.

`python3 main.py aks apply`

Requires a new aad_group_ids config value in config.json to be set.

Does not create an AKV and store KUBECONFIG in the same way the RKE2 deployment does. This could be future work.
Obtain credentials by running `az aks get-credentials` as usual.