### PR TITLE
Bump dsopbuilder to use BigBang v1.36.0 and Customer Template v1.12.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ LABEL "author"="Reuben Cleetus"
 LABEL "version"="1.0"
 LABEL "email"="reuben@cleet.us"
 
-ENV BB_TEMPLATE_VERSION="1.9.0"
-ENV BB_VERSION="1.30.1"
+ENV BB_TEMPLATE_VERSION="1.12.0"
+ENV BB_VERSION="1.36.0"
 
 ENV SOPS_VER="3.7.2"
 ENV KUSTOMIZE_VER="4.5.2"
@@ -43,7 +43,10 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 # Azure CLI
-RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
+RUN curl -sL https://aka.ms/InstallAzureCLIDeb | sed 's/install -y azure-cli/install -y azure-cli=2.36.0-1~jammy/' |bash
+#RUN curl -sL https://aka.ms/InstallAzureCLIDeb | sed 's/apt-get install -y azure-cli/apt-cache madison azure-cli/' | bash
+#RUN apt-get install -y azure-cli=2.36.0-1~focal
+#RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 
 #Terraform
 RUN wget https://releases.hashicorp.com/terraform/1.1.7/terraform_1.1.7_linux_arm64.zip
@@ -63,7 +66,7 @@ RUN curl -sL "https://github.com/kubernetes-sigs/kustomize/releases/download/kus
 #    && chmod +x /usr/bin/kustomize
 
 # Azure CLI
-RUN curl -sL https://aka.ms/InstallAzureCLIDeb |  bash
+#RUN curl -sL https://aka.ms/InstallAzureCLIDeb |  bash
 
 #Flux
 RUN curl -s https://fluxcd.io/install.sh | bash

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,9 +46,6 @@ RUN apt-get update && apt-get install -y \
 
 # Azure CLI
 RUN curl -sL https://aka.ms/InstallAzureCLIDeb | sed 's/install -y azure-cli/install -y azure-cli=2.36.0-1~jammy/' |bash
-#RUN curl -sL https://aka.ms/InstallAzureCLIDeb | sed 's/apt-get install -y azure-cli/apt-cache madison azure-cli/' | bash
-#RUN apt-get install -y azure-cli=2.36.0-1~focal
-#RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
 
 # Terraform
 RUN wget https://releases.hashicorp.com/terraform/1.1.7/terraform_1.1.7_linux_arm64.zip
@@ -66,9 +63,6 @@ RUN curl -sL "https://github.com/kubernetes-sigs/kustomize/releases/download/kus
   && chmod +x /usr/bin/kustomize
 ## RUN curl -L https://github.com/kubernetes-sigs/kustomize/releases/download/v${KUSTOMIZE_VER}/kustomize_${KUSTOMIZE_VER}_linux_amd64  -o /usr/bin/kustomize \
 #    && chmod +x /usr/bin/kustomize
-
-# Azure CLI
-#RUN curl -sL https://aka.ms/InstallAzureCLIDeb |  bash
 
 # Flux
 RUN curl -s https://fluxcd.io/install.sh | bash


### PR DESCRIPTION
Also forces container to use version 2.36.0 of Azure CLI due to a compatibility issue between 2.37.x and older versions of the Terraform azurerm provider.